### PR TITLE
Add support for Wire library for ESP-01

### DIFF
--- a/Adafruit_MCP23017.cpp
+++ b/Adafruit_MCP23017.cpp
@@ -1,4 +1,4 @@
-/*************************************************** 
+/***************************************************
  This is a library for the MCP23017 i2c port expander
 
  These displays use I2C to communicate, 2 pins are required to
@@ -123,6 +123,22 @@ void Adafruit_MCP23017::begin(uint8_t addr) {
 	writeRegister(MCP23017_IODIRA,0xff);
 	writeRegister(MCP23017_IODIRB,0xff);
 }
+
+#ifdef ESP8266
+  void Adafruit_MCP23017::begin(uint8_t addr, uint8_t sda, uint8_t sdc) {
+    if (addr > 7) {
+  		addr = 7;
+  	}
+  	i2caddr = addr;
+
+  	Wire.begin(sda, sdc);
+
+  	// set defaults!
+  	// all inputs on port A and B
+  	writeRegister(MCP23017_IODIRA,0xff);
+  	writeRegister(MCP23017_IODIRB,0xff);
+  }
+#endif
 
 /**
  * Initializes the default MCP23017, with 000 for the configurable part of the address
@@ -287,5 +303,3 @@ uint8_t Adafruit_MCP23017::getLastInterruptPinValue(){
 
 	return MCP23017_INT_ERR;
 }
-
-

--- a/Adafruit_MCP23017.h
+++ b/Adafruit_MCP23017.h
@@ -1,13 +1,13 @@
-/*************************************************** 
+/***************************************************
   This is a library for the MCP23017 i2c port expander
 
-  These displays use I2C to communicate, 2 pins are required to  
+  These displays use I2C to communicate, 2 pins are required to
   interface
-  Adafruit invests time and resources providing this open source code, 
-  please support Adafruit and open-source hardware by purchasing 
+  Adafruit invests time and resources providing this open source code,
+  please support Adafruit and open-source hardware by purchasing
   products from Adafruit!
 
-  Written by Limor Fried/Ladyada for Adafruit Industries.  
+  Written by Limor Fried/Ladyada for Adafruit Industries.
   BSD license, all text above must be included in any redistribution
  ****************************************************/
 
@@ -24,6 +24,9 @@
 class Adafruit_MCP23017 {
 public:
   void begin(uint8_t addr);
+  #ifdef ESP8266
+    void begin(uint8_t addr, uint8_t sda, uint8_t sdc);
+  #endif
   void begin(void);
 
   void pinMode(uint8_t p, uint8_t d);


### PR DESCRIPTION
## Problem

When using the library with ESP-01, the current signatures for `begin()` doesn't allow users to specify SDA and SCL pins. According to Wire library in Arduino core for ESP8266, when calling to `Wire.begin()`, it defaults to 4(SDA) and 5(SCL) which ESP-01 doesn't expose such pins.
## Proposed solution

I create another signature for `begin()` which allows users to pass in SDA and SCL pin numbers. The pin numbers are passed to `Wire.begin(int sda, int scl)`.

```
#ifdef ESP8266
    void begin(uint8_t addr, uint8_t sda, uint8_t sdc);
#endif
```
## Tested

The modified library has been tested and proved to be working. I am currently using the modified library to control relays from MCP23017 I/O ports.
