### PR TITLE
Support INPUT_PULLUP for pinmode(uint8_t pin, uint8_t mode)

### DIFF
--- a/Adafruit_MCP23017.cpp
+++ b/Adafruit_MCP23017.cpp
@@ -127,7 +127,8 @@ void Adafruit_MCP23017::begin(void) {
  * Sets the pin mode to either INPUT or OUTPUT
  */
 void Adafruit_MCP23017::pinMode(uint8_t p, uint8_t d) {
-	updateRegisterBit(p,(d==INPUT),MCP23017_IODIRA,MCP23017_IODIRB);
+	updateRegisterBit(p,(d==INPUT || d==INPUT_PULLUP),MCP23017_IODIRA,MCP23017_IODIRB);
+	if (d == INPUT_PULLUP) pullUp(p, 0xFF);
 }
 
 /**
@@ -140,14 +141,19 @@ uint16_t Adafruit_MCP23017::readGPIOAB() {
 	// read the current GPIO output latches
 	Wire.beginTransmission(MCP23017_ADDRESS | i2caddr);
 	wiresend(MCP23017_GPIOA);
+#ifdef MCP23017_Serial_Debug
+	uint8_t rc_s = Wire.endTransmission();
+#else
 	Wire.endTransmission();
-
+#endif
 	Wire.requestFrom(MCP23017_ADDRESS | i2caddr, 2);
 	a = wirerecv();
 	ba = wirerecv();
 	ba <<= 8;
 	ba |= a;
-
+#ifdef MCP23017_Serial_Debug
+	if (rc_s) Serial.printf("Error %x on reading GPIO (Send to slave)", rc_s);
+#endif
 	return ba;
 }
 

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit MCP23017 Arduino Library
-version=1.0.3
+version=1.0.4
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Library for the MCP23017 I2C Port Expander


### PR DESCRIPTION
+ also added debug code for I2C errors when reading GPIO, define
MCP23017_Serial_Debug to activate
+ bumped patch version in library.properties (1.0.3 -> 1.0.4)

--> See #23 
