### PR TITLE
Added disableInterruptPin

### DIFF
--- a/Adafruit_MCP23017.cpp
+++ b/Adafruit_MCP23017.cpp
@@ -255,6 +255,10 @@ void Adafruit_MCP23017::setupInterruptPin(uint8_t pin, uint8_t mode) {
 
 }
 
+void Adafruit_MCP23017::disableInterruptPin(uint8_t pin) {
+	updateRegisterBit(pin,LOW,MCP23017_GPINTENA,MCP23017_GPINTENB);
+}
+
 uint8_t Adafruit_MCP23017::getLastInterruptPin(){
 	uint8_t intf;
 

--- a/Adafruit_MCP23017.h
+++ b/Adafruit_MCP23017.h
@@ -44,6 +44,7 @@ public:
 
   void setupInterrupts(uint8_t mirroring, uint8_t open, uint8_t polarity);
   void setupInterruptPin(uint8_t p, uint8_t mode);
+  void disableInterruptPin(uint8_t pin);
   uint8_t getLastInterruptPin();
   uint8_t getLastInterruptPinValue();
 


### PR DESCRIPTION
Simple change that adds a function to modify the int enable register in the MCP23017. The ability to easily disable a signal interrupt you've just taken care of to re-enable it in a few milliseconds or seconds to create debounce on switches and PIR sensors is a great feature to have. Tested with a Adafruit feather, to re-enable, simply use mcp.setupInterruptPin like you did to originally enable the interrupt.