### PR TITLE
Override wire begin for ESP8266 to provide PINs

### DIFF
--- a/Adafruit_MCP23017.cpp
+++ b/Adafruit_MCP23017.cpp
@@ -117,6 +117,23 @@ void Adafruit_MCP23017::begin(uint8_t addr) {
 }
 
 /**
+ * Initializes the MCP23017 given its HW selected address, see datasheet for Address selection.
+ */
+void Adafruit_MCP23017::begin(uint8_t addr, uint8_t sda_pin, uint8_t scl_pin) {
+	if (addr > 7) {
+		addr = 7;
+	}
+	i2caddr = addr;
+
+	Wire.begin(sda_pin, scl_pin);
+
+	// set defaults!
+	// all inputs on port A and B
+	writeRegister(MCP23017_IODIRA,0xff);
+	writeRegister(MCP23017_IODIRB,0xff);
+}
+
+/**
  * Initializes the default MCP23017, with 000 for the configurable part of the address
  */
 void Adafruit_MCP23017::begin(void) {

--- a/Adafruit_MCP23017.h
+++ b/Adafruit_MCP23017.h
@@ -31,6 +31,7 @@
 class Adafruit_MCP23017 {
 public:
   void begin(uint8_t addr);
+  void begin(uint8_t addr, uint8_t sda_pin, uint8_t scl_pin);
   void begin(void);
 
   void pinMode(uint8_t p, uint8_t d);


### PR DESCRIPTION

- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This will help us understand any risks of integrating
  the code.
The scope of the change is to implement an begin override to provide 'custom' pins e.g. required for ESP8266. 
- **Describe any known limitations with your change.**  None that i'm aware of. basic functionality shall remain as is. 

- **Please run any tests or examples that can exercise your modified code.**  Verified this locally with I2C. 
