### PR TITLE
Reset pin issue, address pin unification

### DIFF
--- a/Adafruit_MCP23017.cpp
+++ b/Adafruit_MCP23017.cpp
@@ -103,6 +103,10 @@ void Adafruit_MCP23017::updateRegisterBit(uint8_t pin, uint8_t pValue, uint8_t p
  * Initializes the MCP23017 given its HW selected address, see datasheet for Address selection.
  */
 void Adafruit_MCP23017::begin(uint8_t addr) {
+        // allow using both syntaxes, complete i2x address or address pin setting
+	if ((addr >= MCP23017_ADDRESS) && (addr < (MCP23017_ADDRESS+8))) {
+		addr -= MCP23017_ADDRESS;
+	}	
 	if (addr > 7) {
 		addr = 7;
 	}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@ This is a library for the MCP23017 I2c Port Expander
  
 These chips use I2C to communicate, 2 pins required to interface
 
+Reset pin should always be kept high, pulling it low would require a new initialization afterwards
+
 Adafruit invests time and resources providing this open source code, 
 please support Adafruit and open-source hardware by purchasing 
 products from Adafruit!

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ This is a library for the MCP23017 I2c Port Expander
  
 These chips use I2C to communicate, 2 pins required to interface
 
-Reset pin should always be kept high, pulling it low would require a new initialization afterwards
+Reset pin should always be kept high, pulling it low would require a new initialization afterwards 
 
 Adafruit invests time and resources providing this open source code, 
 please support Adafruit and open-source hardware by purchasing 

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit MCP23017 Arduino Library
-version=1.0.6
+version=1.0.7
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Library for the MCP23017 I2C Port Expander


### PR DESCRIPTION
2 additions:
 - Readme: I started experimenting with the chip with one output pin at the MCP23017-reset pin, and the setup() with mcp.being(), and then pulled the reset pin HIGH. This never worked, even though the wiring was fine, and even i2c-scanners find the device without problems. This took me ages to find out, so I wanted to spare this trouble to others. Also, pulling the reset pin low and high later on in the code would require another initialization with the default register entries. So better never pull it low at any stage.
 - address: some MCP23017-libraries initialize with the address pin settings (like this one), others with the complete i2c address (most others). This simple change would allow both syntaxes.