### PR TITLE
added changeAddress to support multiple MCP23017 with one instance

### DIFF
--- a/Adafruit_MCP23017.cpp
+++ b/Adafruit_MCP23017.cpp
@@ -124,6 +124,43 @@ void Adafruit_MCP23017::begin(void) {
 }
 
 /**
+ * Changes the adress to which MCP23017 is talked to.
+ * Initializing all ports as input is optional.
+ * This enables the option to control multiple MCP23017 with one instance.
+ * Both adress syntax (i2x) = 0x20 or only the configurable part is supported.
+ */
+void Adafruit_MCP23017::changeAddress(uint8_t addr, bool initAsInput) {
+
+	// allow using both syntaxes, complete i2x address or address pin setting
+	if ((addr >= MCP23017_ADDRESS) && (addr < (MCP23017_ADDRESS+8))) {
+		addr -= MCP23017_ADDRESS;
+	}
+
+	if (addr > 7) {
+		addr = 7;
+	}
+
+	i2caddr = addr;
+
+	if (initAsInput){
+		// set defaults only if wanted.
+		// all inputs on port A and B
+		writeRegister(MCP23017_IODIRA,0xff);
+		writeRegister(MCP23017_IODIRB,0xff);
+	}
+}
+
+/**
+ * Changes the adress to which MCP23017 is talked to.
+ * This enables the option to control multiple MCP23017 with one instance.
+ * Both adress syntax (i2x) = 0x20 or only the configurable part is supported.
+ */
+void Adafruit_MCP23017::changeAddress(uint8_t addr) {
+	changeAddress(addr,false);
+}
+
+
+/**
  * Sets the pin mode to either INPUT or OUTPUT
  */
 void Adafruit_MCP23017::pinMode(uint8_t p, uint8_t d) {

--- a/Adafruit_MCP23017.cpp
+++ b/Adafruit_MCP23017.cpp
@@ -142,6 +142,9 @@ void Adafruit_MCP23017::begin(TwoWire *theWire) { begin(0, theWire); }
  * Initializing all ports as input is optional.
  * This enables the option to control multiple MCP23017 with one instance.
  * Both adress syntax (i2x) = 0x20 or only the configurable part is supported.
+ * @param addr Selected address
+ * @param initAsInput If true initializing all ports as input, otherwise they
+ * stay as they are
  */
 void Adafruit_MCP23017::changeAddress(uint8_t addr, bool initAsInput) {
   // allow using both syntaxes, complete i2x address or address pin setting
@@ -167,6 +170,7 @@ void Adafruit_MCP23017::changeAddress(uint8_t addr, bool initAsInput) {
  * Changes the adress to which MCP23017 is talked to.
  * This enables the option to control multiple MCP23017 with one instance.
  * Both adress syntax (i2x) = 0x20 or only the configurable part is supported.
+ * @param addr Selected address
  */
 void Adafruit_MCP23017::changeAddress(uint8_t addr) {
   changeAddress(addr, false);

--- a/Adafruit_MCP23017.cpp
+++ b/Adafruit_MCP23017.cpp
@@ -130,7 +130,6 @@ void Adafruit_MCP23017::begin(void) {
  * Both adress syntax (i2x) = 0x20 or only the configurable part is supported.
  */
 void Adafruit_MCP23017::changeAddress(uint8_t addr, bool initAsInput) {
-
 	// allow using both syntaxes, complete i2x address or address pin setting
 	if ((addr >= MCP23017_ADDRESS) && (addr < (MCP23017_ADDRESS+8))) {
 		addr -= MCP23017_ADDRESS;

--- a/Adafruit_MCP23017.cpp
+++ b/Adafruit_MCP23017.cpp
@@ -144,23 +144,23 @@ void Adafruit_MCP23017::begin(TwoWire *theWire) { begin(0, theWire); }
  * Both adress syntax (i2x) = 0x20 or only the configurable part is supported.
  */
 void Adafruit_MCP23017::changeAddress(uint8_t addr, bool initAsInput) {
-	// allow using both syntaxes, complete i2x address or address pin setting
-	if ((addr >= MCP23017_ADDRESS) && (addr < (MCP23017_ADDRESS+8))) {
-		addr -= MCP23017_ADDRESS;
-	}
+  // allow using both syntaxes, complete i2x address or address pin setting
+  if ((addr >= MCP23017_ADDRESS) && (addr < (MCP23017_ADDRESS + 8))) {
+    addr -= MCP23017_ADDRESS;
+  }
 
-	if (addr > 7) {
-		addr = 7;
-	}
+  if (addr > 7) {
+    addr = 7;
+  }
 
-	i2caddr = addr;
+  i2caddr = addr;
 
-	if (initAsInput){
-		// set defaults only if wanted.
-		// all inputs on port A and B
-		writeRegister(MCP23017_IODIRA,0xff);
-		writeRegister(MCP23017_IODIRB,0xff);
-	}
+  if (initAsInput) {
+    // set defaults only if wanted.
+    // all inputs on port A and B
+    writeRegister(MCP23017_IODIRA, 0xff);
+    writeRegister(MCP23017_IODIRB, 0xff);
+  }
 }
 
 /**
@@ -169,9 +169,8 @@ void Adafruit_MCP23017::changeAddress(uint8_t addr, bool initAsInput) {
  * Both adress syntax (i2x) = 0x20 or only the configurable part is supported.
  */
 void Adafruit_MCP23017::changeAddress(uint8_t addr) {
-	changeAddress(addr,false);
+  changeAddress(addr, false);
 }
-
 
 /**
  * Changes the adress to which MCP23017 is talked to.
@@ -180,23 +179,23 @@ void Adafruit_MCP23017::changeAddress(uint8_t addr) {
  * Both adress syntax (i2x) = 0x20 or only the configurable part is supported.
  */
 void Adafruit_MCP23017::changeAddress(uint8_t addr, bool initAsInput) {
-	// allow using both syntaxes, complete i2x address or address pin setting
-	if ((addr >= MCP23017_ADDRESS) && (addr < (MCP23017_ADDRESS+8))) {
-		addr -= MCP23017_ADDRESS;
-	}
+  // allow using both syntaxes, complete i2x address or address pin setting
+  if ((addr >= MCP23017_ADDRESS) && (addr < (MCP23017_ADDRESS + 8))) {
+    addr -= MCP23017_ADDRESS;
+  }
 
-	if (addr > 7) {
-		addr = 7;
-	}
+  if (addr > 7) {
+    addr = 7;
+  }
 
-	i2caddr = addr;
+  i2caddr = addr;
 
-	if (initAsInput){
-		// set defaults only if wanted.
-		// all inputs on port A and B
-		writeRegister(MCP23017_IODIRA,0xff);
-		writeRegister(MCP23017_IODIRB,0xff);
-	}
+  if (initAsInput) {
+    // set defaults only if wanted.
+    // all inputs on port A and B
+    writeRegister(MCP23017_IODIRA, 0xff);
+    writeRegister(MCP23017_IODIRB, 0xff);
+  }
 }
 
 /**
@@ -205,9 +204,8 @@ void Adafruit_MCP23017::changeAddress(uint8_t addr, bool initAsInput) {
  * Both adress syntax (i2x) = 0x20 or only the configurable part is supported.
  */
 void Adafruit_MCP23017::changeAddress(uint8_t addr) {
-	changeAddress(addr,false);
+  changeAddress(addr, false);
 }
-
 
 /**
  * Sets the pin mode to either INPUT or OUTPUT

--- a/Adafruit_MCP23017.cpp
+++ b/Adafruit_MCP23017.cpp
@@ -173,41 +173,6 @@ void Adafruit_MCP23017::changeAddress(uint8_t addr) {
 }
 
 /**
- * Changes the adress to which MCP23017 is talked to.
- * Initializing all ports as input is optional.
- * This enables the option to control multiple MCP23017 with one instance.
- * Both adress syntax (i2x) = 0x20 or only the configurable part is supported.
- */
-void Adafruit_MCP23017::changeAddress(uint8_t addr, bool initAsInput) {
-  // allow using both syntaxes, complete i2x address or address pin setting
-  if ((addr >= MCP23017_ADDRESS) && (addr < (MCP23017_ADDRESS + 8))) {
-    addr -= MCP23017_ADDRESS;
-  }
-
-  if (addr > 7) {
-    addr = 7;
-  }
-
-  i2caddr = addr;
-
-  if (initAsInput) {
-    // set defaults only if wanted.
-    // all inputs on port A and B
-    writeRegister(MCP23017_IODIRA, 0xff);
-    writeRegister(MCP23017_IODIRB, 0xff);
-  }
-}
-
-/**
- * Changes the adress to which MCP23017 is talked to.
- * This enables the option to control multiple MCP23017 with one instance.
- * Both adress syntax (i2x) = 0x20 or only the configurable part is supported.
- */
-void Adafruit_MCP23017::changeAddress(uint8_t addr) {
-  changeAddress(addr, false);
-}
-
-/**
  * Sets the pin mode to either INPUT or OUTPUT
  * @param p Pin to set
  * @param d Mode to set the pin

--- a/Adafruit_MCP23017.h
+++ b/Adafruit_MCP23017.h
@@ -32,6 +32,8 @@ class Adafruit_MCP23017 {
 public:
   void begin(uint8_t addr);
   void begin(void);
+  void changeAddress(uint8_t addr, bool initAsInput);
+  void changeAddress(uint8_t addr);
 
   void pinMode(uint8_t p, uint8_t d);
   void digitalWrite(uint8_t p, uint8_t d);

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit MCP23017 Arduino Library
-version=1.0.5
+version=1.0.6
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Library for the MCP23017 I2C Port Expander


### PR DESCRIPTION
- Initial problem:
mcp.begin();
causes a reset on all pins -> all set to INPUT

- Scope:
Added "changeAddress" to support multiple MCP23017 with one instance of "mcp"
With this it is possible to run up to 8 devices on one instance without the need to reconfigure pins.
Additionally added extended support for use of 0x20 + default as address like in #39

- Limits:
none

- Tests
I tested it with at least 2 devices and got no problem.

- Example:
mcp.begin(0);
mcp.pinMode(0, OUTPUT);
mcp.pinMode(1, INPUT);
mcp.pullUp(1, HIGH);
mcp.digitalWrite(0, HIGH);
mcp.changeAddress(1);
mcp.digitalWrite(0, HIGH);
mcp.changeAddress(0);
mcp.digitalWrite(0,LOW); // pullup + output no lost in settings