### PR TITLE
Return wire transmission result from begin() and writeRegister()

### DIFF
--- a/Adafruit_MCP23017.cpp
+++ b/Adafruit_MCP23017.cpp
@@ -85,7 +85,7 @@ bool Adafruit_MCP23017::writeRegister(uint8_t regAddr, uint8_t regValue){
  * - Reads the current register value
  * - Writes the new register value
  */
-void Adafruit_MCP23017::updateRegisterBit(uint8_t pin, uint8_t pValue, uint8_t portAaddr, uint8_t portBaddr) {
+bool Adafruit_MCP23017::updateRegisterBit(uint8_t pin, uint8_t pValue, uint8_t portAaddr, uint8_t portBaddr) {
 	uint8_t regValue;
 	uint8_t regAddr=regForPin(pin,portAaddr,portBaddr);
 	uint8_t bit=bitForPin(pin);
@@ -94,7 +94,7 @@ void Adafruit_MCP23017::updateRegisterBit(uint8_t pin, uint8_t pValue, uint8_t p
 	// set the value for the particular bit
 	bitWrite(regValue,bit,pValue);
 
-	writeRegister(regAddr,regValue);
+	return writeRegister(regAddr,regValue);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -129,8 +129,8 @@ bool Adafruit_MCP23017::begin(void) {
 /**
  * Sets the pin mode to either INPUT or OUTPUT
  */
-void Adafruit_MCP23017::pinMode(uint8_t p, uint8_t d) {
-	updateRegisterBit(p,(d==INPUT),MCP23017_IODIRA,MCP23017_IODIRB);
+bool Adafruit_MCP23017::pinMode(uint8_t p, uint8_t d) {
+	return updateRegisterBit(p,(d==INPUT),MCP23017_IODIRA,MCP23017_IODIRB);
 }
 
 /**

--- a/Adafruit_MCP23017.cpp
+++ b/Adafruit_MCP23017.cpp
@@ -71,12 +71,12 @@ uint8_t Adafruit_MCP23017::readRegister(uint8_t addr){
 /**
  * Writes a given register
  */
-void Adafruit_MCP23017::writeRegister(uint8_t regAddr, uint8_t regValue){
+bool Adafruit_MCP23017::writeRegister(uint8_t regAddr, uint8_t regValue){
 	// Write the register
 	Wire.beginTransmission(MCP23017_ADDRESS | i2caddr);
 	wiresend(regAddr);
 	wiresend(regValue);
-	Wire.endTransmission();
+	return Wire.endTransmission() == 0;
 }
 
 
@@ -102,7 +102,7 @@ void Adafruit_MCP23017::updateRegisterBit(uint8_t pin, uint8_t pValue, uint8_t p
 /**
  * Initializes the MCP23017 given its HW selected address, see datasheet for Address selection.
  */
-void Adafruit_MCP23017::begin(uint8_t addr) {
+bool Adafruit_MCP23017::begin(uint8_t addr) {
 	if (addr > 7) {
 		addr = 7;
 	}
@@ -112,15 +112,18 @@ void Adafruit_MCP23017::begin(uint8_t addr) {
 
 	// set defaults!
 	// all inputs on port A and B
-	writeRegister(MCP23017_IODIRA,0xff);
-	writeRegister(MCP23017_IODIRB,0xff);
+	bool dirA = writeRegister(MCP23017_IODIRA,0xff);
+	bool dirB = writeRegister(MCP23017_IODIRB,0xff);
+	bool polA = writeRegister(MCP23017_IPOLA, 0x00);
+	bool polB = writeRegister(MCP23017_IPOLB, 0x00);
+	return dirA && dirB && polA && polB;
 }
 
 /**
  * Initializes the default MCP23017, with 000 for the configurable part of the address
  */
-void Adafruit_MCP23017::begin(void) {
-	begin(0);
+bool Adafruit_MCP23017::begin(void) {
+	return begin(0);
 }
 
 /**

--- a/Adafruit_MCP23017.h
+++ b/Adafruit_MCP23017.h
@@ -33,7 +33,7 @@ public:
   bool begin(uint8_t addr);
   bool begin(void);
 
-  void pinMode(uint8_t p, uint8_t d);
+  bool pinMode(uint8_t p, uint8_t d);
   void digitalWrite(uint8_t p, uint8_t d);
   void pullUp(uint8_t p, uint8_t d);
   uint8_t digitalRead(uint8_t p);
@@ -60,7 +60,7 @@ public:
    * Utility private method to update a register associated with a pin (whether port A/B)
    * reads its value, updates the particular bit, and writes its value.
    */
-  void updateRegisterBit(uint8_t p, uint8_t pValue, uint8_t portAaddr, uint8_t portBaddr);
+  bool updateRegisterBit(uint8_t p, uint8_t pValue, uint8_t portAaddr, uint8_t portBaddr);
 
 };
 

--- a/Adafruit_MCP23017.h
+++ b/Adafruit_MCP23017.h
@@ -30,8 +30,8 @@
 
 class Adafruit_MCP23017 {
 public:
-  void begin(uint8_t addr);
-  void begin(void);
+  bool begin(uint8_t addr);
+  bool begin(void);
 
   void pinMode(uint8_t p, uint8_t d);
   void digitalWrite(uint8_t p, uint8_t d);
@@ -54,7 +54,7 @@ public:
   uint8_t regForPin(uint8_t pin, uint8_t portAaddr, uint8_t portBaddr);
 
   uint8_t readRegister(uint8_t addr);
-  void writeRegister(uint8_t addr, uint8_t value);
+  bool writeRegister(uint8_t addr, uint8_t value);
 
   /**
    * Utility private method to update a register associated with a pin (whether port A/B)


### PR DESCRIPTION
- This change uses the return value from Wire.endTransmission() to tell the caller if the operation was successful for the begin() call.
- This change also clears the inverse polarity registers during a begin call. If this is is no good, let me know and I'll make writeRegister public instead.
- I don't know if endTransmission's return code is reliable on all platforms. This would not reduce functionality on any platform since the return value may be safely ignored.

I've been working on a split mechanical keyboard with a remote MCP23017 and am currently running this code, so it's currently tested OK.
fork.begin() having a return status helps me drop into a debug loop when the keyboard is not properly connected.
IPOL registers being cleared was necessary for my chip to function as expected. I did wire the reset line high, as per the chip docs, but this register was still in an unpredictable state at startup.