### PR TITLE
Add disableInterruptPin() 

### DIFF
--- a/Adafruit_MCP23017.cpp
+++ b/Adafruit_MCP23017.cpp
@@ -295,6 +295,17 @@ void Adafruit_MCP23017::setupInterruptPin(uint8_t pin, uint8_t mode) {
   updateRegisterBit(pin, HIGH, MCP23017_GPINTENA, MCP23017_GPINTENB);
 }
 
+/**
+ * Disable a pin for interrupt.
+ *
+ * @param pin Pin to set
+ *
+ */
+void Adafruit_MCP23017::disableInterruptPin(uint8_t pin) {
+  // disable the pin for interrupt
+  updateRegisterBit(pin, LOW, MCP23017_GPINTENA, MCP23017_GPINTENB);
+}
+
 /*!
  * @brief Gets the last interrupt pin
  * @return Returns the last interrupt pin

--- a/Adafruit_MCP23017.h
+++ b/Adafruit_MCP23017.h
@@ -36,7 +36,8 @@ public:
   uint8_t readGPIO(uint8_t b);
 
   void setupInterrupts(uint8_t mirroring, uint8_t open, uint8_t polarity);
-  void setupInterruptPin(uint8_t p, uint8_t mode);
+  void setupInterruptPin(uint8_t pin, uint8_t mode);
+  void disableInterruptPin(uint8_t pin);
   uint8_t getLastInterruptPin();
   uint8_t getLastInterruptPinValue();
 


### PR DESCRIPTION
- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  
Add disableInterruptPin() function to remove interrupt notifications from specific pin.

- **Describe any known limitations with your change.**  
None

- **Please run any tests or examples that can exercise your modified code.**  
Works fine. ALSO PLEASE CONSIDER DISABLING ALL INTERRUPTS ON BEGIN()! This really hosed me for several hours as it did not occur to me that I wasn't resetting the MCP when resetting my board... I was commenting out the setupInterruptPin() but it was already set from previous code.
