### PR TITLE
Made changes to allow use of all bits of Port A or B to be used together

### DIFF
--- a/Adafruit_MCP23017.cpp
+++ b/Adafruit_MCP23017.cpp
@@ -155,6 +155,55 @@ void Adafruit_MCP23017::pinMode(uint8_t p, uint8_t d) {
 }
 
 /**
+ * Sets the port mode to either INPUT or OUTPUT
+ * @param b Decide which gpio to use. Should be 0 for GPIOA, and 1 for GPIOB.
+ * @param d Mode to set the port
+ */
+void Adafruit_MCP23017::portMode(uint8_t b, uint8_t d) {
+	uint8_t addrIODIR = MCP23017_IODIRA;
+	uint8_t addrGPPU = MCP23017_GPPUA;
+	
+	if(b == MCP23017_PORT_B) {
+		addrIODIR = MCP23017_IODIRB;
+		addrGPPU = MCP23017_GPPUB;
+	}
+	
+	switch(d) {
+		case INPUT:
+			writeRegister(addrIODIR, 0xff);
+			writeRegister(addrGPPU, 0x00);
+			break;
+		case INPUT_PULLUP:
+			writeRegister(addrIODIR, 0xff);
+			writeRegister(addrGPPU, 0xff);
+			break;
+		case OUTPUT:
+			writeRegister(addrIODIR, 0x00);
+			break;
+	}
+}
+
+/**
+ * Sets the port mode to either non-inverted or inverted
+ * @param b Decide which gpio to use. Should be 0 for GPIOA, and 1 for GPIOB.
+ * @param d Polarity 0 = non-inverted, 1 = inverted
+ */
+void Adafruit_MCP23017::portPolarity(uint8_t b, uint8_t d) {
+	uint8_t addrIPOL = MCP23017_IPOLA;
+	
+	if(b == MCP23017_PORT_B) {
+		addrIPOL = MCP23017_IPOLB;
+	}
+	
+	if(d == 0) {	// non-inverted
+		writeRegister(addrIPOL, 0x00);
+	}
+	else {				// inverted
+		writeRegister(addrIPOL, 0xff);
+	}
+}
+
+/**
  * Reads all 16 pins (port A and B) into a single 16 bits variable.
  * @return Returns the 16 bit variable representing all 16 pins
  */
@@ -205,6 +254,22 @@ void Adafruit_MCP23017::writeGPIOAB(uint16_t ba) {
   wiresend(MCP23017_GPIOA, _wire);
   wiresend(ba & 0xFF, _wire);
   wiresend(ba >> 8, _wire);
+  _wire->endTransmission();
+}
+
+/**
+ * Write a single port, A or B. 
+ * @param b Decide which gpio to use. Should be 0 for GPIOA, and 1 for GPIOB.
+ * @param d byte of data to send
+ */
+void Adafruit_MCP23017::writeGPIO(uint8_t b, uint8_t d) {
+  _wire->beginTransmission(MCP23017_ADDRESS | i2caddr);
+  if (b == MCP23017_PORT_A)
+    wiresend(MCP23017_GPIOA, _wire);
+  else {
+    wiresend(MCP23017_GPIOB, _wire);
+  }
+  wiresend(d, _wire);
   _wire->endTransmission();
 }
 

--- a/Adafruit_MCP23017.h
+++ b/Adafruit_MCP23017.h
@@ -27,11 +27,14 @@ public:
   void begin(TwoWire *theWire = &Wire);
 
   void pinMode(uint8_t p, uint8_t d);
+  void portMode(uint8_t b, uint8_t d);
+  void portPolarity(uint8_t b, uint8_t d);
   void digitalWrite(uint8_t p, uint8_t d);
   void pullUp(uint8_t p, uint8_t d);
   uint8_t digitalRead(uint8_t p);
 
   void writeGPIOAB(uint16_t);
+  void writeGPIO(uint8_t b, uint8_t d);
   uint16_t readGPIOAB();
   uint8_t readGPIO(uint8_t b);
 
@@ -61,6 +64,10 @@ private:
 };
 
 #define MCP23017_ADDRESS 0x20 //!< MCP23017 Address
+
+// ports
+#define MCP23017_PORT_A 0x00
+#define MCP23017_PORT_B 0x01
 
 // registers
 #define MCP23017_IODIRA 0x00   //!< I/O direction register A

--- a/examples/keypad/keypad.ino
+++ b/examples/keypad/keypad.ino
@@ -1,0 +1,66 @@
+#include <Wire.h>
+#include "Adafruit_MCP23017.h"
+
+/*
+   Example code for reading an 8x8 keypad matrix using the MCP23017 I2c Port Expander
+   This example is not a complete example as it does not include
+    - debouncing
+    - key press events
+
+    Rows are ouputs at the Arduino and connected to MCP23017 Port A
+    Columns are inputs at the Arduino and connected to MCP23017 Port B
+    
+    Written by Richard Teel for TeelSys LLC.
+*/
+
+#define scantime 100
+
+Adafruit_MCP23017 mcp;
+
+unsigned long previousScanMillis = 0;
+
+void setup() {
+  mcp.begin();      // use default address 0
+  // Set port direction
+  mcp.portMode(MCP23017_PORT_A, OUTPUT);
+  mcp.portMode(MCP23017_PORT_B, INPUT_PULLUP);
+  mcp.portPolarity(MCP23017_PORT_B, true);
+  mcp.writeGPIO(MCP23017_PORT_A, 0xff); // write 0xff to Port A
+
+  Serial.begin(115200);   // PC for debuging
+}
+
+void loop() {
+  unsigned long currentScanMillis = millis();
+
+  if (currentScanMillis - previousScanMillis >= scantime) {
+    previousScanMillis = currentScanMillis;
+
+    uint8_t keyPressed = 0;
+
+    for (uint8_t row = 0; row < 8; row++) {
+      uint8_t q = ~(0x01 << row);
+      mcp.writeGPIO(MCP23017_PORT_A, ~(0x01 << row)); // write rowScan to Port A to set row to 0 (low)
+
+      uint8_t scanValue = mcp.readGPIO(MCP23017_PORT_B);
+
+      // Check if a key was pressed in the row
+      if (scanValue != 0x00) {
+        uint8_t scanCode = 0;
+
+        for (uint8_t col = 0; col < 8; col++) {
+          // Was the key in the column pressed?
+          if ((scanValue >> col) & 0x01 == 0x01) {
+            keyPressed = 1;
+            scanCode = (row * 8) + (col + 1);
+            Serial.print("SCAN CODE = "); Serial.print(scanCode); Serial.print(", ROW = "); Serial.print(row); Serial.print(", COL = "); Serial.println(col);
+          }
+        }
+      }
+    }
+    // Prints line to group multiple key presses together
+    if (keyPressed) {
+      Serial.println("---");
+    }
+  }
+}

--- a/keywords.txt
+++ b/keywords.txt
@@ -13,7 +13,11 @@ MCP23017	KEYWORD1
 #######################################
 
 pullUp	KEYWORD2
+portMode	KEYWORD2
+portPolarity	KEYWORD2
+writeGPIO	KEYWORD2
 writeGPIOAB	KEYWORD2
+readGPIO	KEYWORD2
 readGPIOAB	KEYWORD2
 
 #######################################


### PR DESCRIPTION
Added methods to Adafruit_MCP23017 class to speed up operations when using all bits of a port together

	- portMode(uint8_t b, uint8_t d) Sets all bits of a port to INPUT, INPUT_PULLUP, or OUTPUT
	- portPolarity(uint8_t b, uint8_t d) Inverts or not invert all bits on a port
	- writeGPIO(uint8_t b, uint8_t d) Write data to all the bits of a port

Defined two new constants to aid port operations
	- MCP23017_PORT_A
	- MCP23017_PORT_B

Added four keywords for three new methods and one existing method

Added keypad example