### PR TITLE
Added readout of output latches using the OLAT register

### DIFF
--- a/Adafruit_MCP23017.cpp
+++ b/Adafruit_MCP23017.cpp
@@ -197,6 +197,47 @@ uint8_t Adafruit_MCP23017::readGPIO(uint8_t b) {
 }
 
 /**
+ * Reads all 16 pins output state (OLAT register) into a single 16 bits variable.
+ */
+uint16_t Adafruit_MCP23017::readOutputsAB() {
+  uint16_t ba = 0;
+  uint8_t a;
+
+  // read the current OLAT output latches
+  _wire->beginTransmission(MCP23017_ADDRESS | i2caddr);
+  wiresend(MCP23017_OLATA, _wire);
+  _wire->endTransmission();
+
+  _wire->requestFrom(MCP23017_ADDRESS | i2caddr, 2);
+  a = wirerecv(_wire);
+  ba = wirerecv(_wire);
+  ba <<= 8;
+  ba |= a;
+
+  return ba;
+}
+
+/**
+ * Read output state of a single port, A or B, and return its current 8 bit value.
+ * @param b Decided what gpio to use. Should be 0 for GPIOA, and 1 for GPIOB.
+ * @return Returns the b bit value of the port
+ */
+uint8_t Adafruit_MCP23017::readOutputs(uint8_t b) {
+
+  // read the current OLAT output latches
+  _wire->beginTransmission(MCP23017_ADDRESS | i2caddr);
+  if (b == 0)
+    wiresend(MCP23017_OLATA, _wire);
+  else {
+    wiresend(MCP23017_OLATB, _wire);
+  }
+  _wire->endTransmission();
+
+  _wire->requestFrom(MCP23017_ADDRESS | i2caddr, 1);
+  return wirerecv(_wire);
+}
+
+/**
  * Writes all the pins in one go. This method is very useful if you are
  * implementing a multiplexed matrix and want to get a decent refresh rate.
  */

--- a/Adafruit_MCP23017.cpp
+++ b/Adafruit_MCP23017.cpp
@@ -197,7 +197,8 @@ uint8_t Adafruit_MCP23017::readGPIO(uint8_t b) {
 }
 
 /**
- * Reads all 16 pins output state (OLAT register) into a single 16 bits variable.
+ * Reads all 16 pins output state (OLAT register) into a single 16 bits 
+ * variable.
  */
 uint16_t Adafruit_MCP23017::readOutputsAB() {
   uint16_t ba = 0;
@@ -218,7 +219,8 @@ uint16_t Adafruit_MCP23017::readOutputsAB() {
 }
 
 /**
- * Read output state of a single port, A or B, and return its current 8 bit value.
+ * Read output state of a single port, A or B, and return its current 8 bit 
+ * value.
  * @param b Decided what gpio to use. Should be 0 for GPIOA, and 1 for GPIOB.
  * @return Returns the b bit value of the port
  */

--- a/Adafruit_MCP23017.cpp
+++ b/Adafruit_MCP23017.cpp
@@ -197,7 +197,7 @@ uint8_t Adafruit_MCP23017::readGPIO(uint8_t b) {
 }
 
 /**
- * Reads all 16 pins output state (OLAT register) into a single 16 bits 
+ * Reads all 16 pins output state (OLAT register) into a single 16 bits
  * variable.
  * @return Returns the 16 bit variable representing all 16 pins outputs
  */
@@ -220,7 +220,7 @@ uint16_t Adafruit_MCP23017::readOutputsAB() {
 }
 
 /**
- * Read output state of a single port, A or B, and return its current 8 bit 
+ * Read output state of a single port, A or B, and return its current 8 bit
  * value.
  * @param b Decides what gpio to use. Should be 0 for GPIOA, and 1 for GPIOB.
  * @return Returns the b bit value of the output state of the port

--- a/Adafruit_MCP23017.cpp
+++ b/Adafruit_MCP23017.cpp
@@ -178,7 +178,7 @@ uint16_t Adafruit_MCP23017::readGPIOAB() {
 
 /**
  * Read a single port, A or B, and return its current 8 bit value.
- * @param b Decided what gpio to use. Should be 0 for GPIOA, and 1 for GPIOB.
+ * @param b Decides what gpio to use. Should be 0 for GPIOA, and 1 for GPIOB.
  * @return Returns the b bit value of the port
  */
 uint8_t Adafruit_MCP23017::readGPIO(uint8_t b) {
@@ -199,6 +199,7 @@ uint8_t Adafruit_MCP23017::readGPIO(uint8_t b) {
 /**
  * Reads all 16 pins output state (OLAT register) into a single 16 bits 
  * variable.
+ * @return Returns the 16 bit variable representing all 16 pins outputs
  */
 uint16_t Adafruit_MCP23017::readOutputsAB() {
   uint16_t ba = 0;
@@ -221,8 +222,8 @@ uint16_t Adafruit_MCP23017::readOutputsAB() {
 /**
  * Read output state of a single port, A or B, and return its current 8 bit 
  * value.
- * @param b Decided what gpio to use. Should be 0 for GPIOA, and 1 for GPIOB.
- * @return Returns the b bit value of the port
+ * @param b Decides what gpio to use. Should be 0 for GPIOA, and 1 for GPIOB.
+ * @return Returns the b bit value of the output state of the port
  */
 uint8_t Adafruit_MCP23017::readOutputs(uint8_t b) {
 

--- a/Adafruit_MCP23017.h
+++ b/Adafruit_MCP23017.h
@@ -34,6 +34,8 @@ public:
   void writeGPIOAB(uint16_t);
   uint16_t readGPIOAB();
   uint8_t readGPIO(uint8_t b);
+  uint16_t readOutputsAB();
+  uint8_t readOutputs(uint8_t b);
 
   void setupInterrupts(uint8_t mirroring, uint8_t open, uint8_t polarity);
   void setupInterruptPin(uint8_t pin, uint8_t mode);

--- a/Adafruit_MCP23017.h
+++ b/Adafruit_MCP23017.h
@@ -65,29 +65,29 @@ private:
 #define MCP23017_ADDRESS 0x20 //!< MCP23017 Address
 
 // registers
-#define MCP23017_IODIRA 0x00   //!< I/O direction register A
-#define MCP23017_IPOLA 0x02    //!< Input polarity port register A
+#define MCP23017_IODIRA 0x00 //!< I/O direction register A
+#define MCP23017_IPOLA 0x02 //!< Input polarity port register A
 #define MCP23017_GPINTENA 0x04 //!< Interrupt-on-change pins A
-#define MCP23017_DEFVALA 0x06  //!< Default value register A
-#define MCP23017_INTCONA 0x08  //!< Interrupt-on-change control register A
-#define MCP23017_IOCONA 0x0A   //!< I/O expander configuration register A
-#define MCP23017_GPPUA 0x0C    //!< GPIO pull-up resistor register A
-#define MCP23017_INTFA 0x0E    //!< Interrupt flag register A
-#define MCP23017_INTCAPA 0x10  //!< Interrupt captured value for port register A
-#define MCP23017_GPIOA 0x12    //!< General purpose I/O port register A
-#define MCP23017_OLATA 0x14    //!< Output latch register 0 A
+#define MCP23017_DEFVALA 0x06 //!< Default value register A
+#define MCP23017_INTCONA 0x08 //!< Interrupt-on-change control register A
+#define MCP23017_IOCONA 0x0A //!< I/O expander configuration register A
+#define MCP23017_GPPUA 0x0C //!< GPIO pull-up resistor register A
+#define MCP23017_INTFA 0x0E //!< Interrupt flag register A
+#define MCP23017_INTCAPA 0x10 //!< Interrupt captured value for port register A
+#define MCP23017_GPIOA 0x12 //!< General purpose I/O port register A
+#define MCP23017_OLATA 0x14 //!< Output latch register 0 A
 
-#define MCP23017_IODIRB 0x01   //!< I/O direction register B
-#define MCP23017_IPOLB 0x03    //!< Input polarity port register B
+#define MCP23017_IODIRB 0x01 //!< I/O direction register B
+#define MCP23017_IPOLB 0x03 //!< Input polarity port register B
 #define MCP23017_GPINTENB 0x05 //!< Interrupt-on-change pins B
-#define MCP23017_DEFVALB 0x07  //!< Default value register B
-#define MCP23017_INTCONB 0x09  //!< Interrupt-on-change control register B
-#define MCP23017_IOCONB 0x0B   //!< I/O expander configuration register B
-#define MCP23017_GPPUB 0x0D    //!< GPIO pull-up resistor register B
-#define MCP23017_INTFB 0x0F    //!< Interrupt flag register B
-#define MCP23017_INTCAPB 0x11  //!< Interrupt captured value for port register B
-#define MCP23017_GPIOB 0x13    //!< General purpose I/O port register B
-#define MCP23017_OLATB 0x15    //!< Output latch register 0 B
+#define MCP23017_DEFVALB 0x07 //!< Default value register B
+#define MCP23017_INTCONB 0x09 //!< Interrupt-on-change control register B
+#define MCP23017_IOCONB 0x0B //!< I/O expander configuration register B
+#define MCP23017_GPPUB 0x0D //!< GPIO pull-up resistor register B
+#define MCP23017_INTFB 0x0F //!< Interrupt flag register B
+#define MCP23017_INTCAPB 0x11 //!< Interrupt captured value for port register B
+#define MCP23017_GPIOB 0x13 //!< General purpose I/O port register B
+#define MCP23017_OLATB 0x15 //!< Output latch register 0 B
 
 #define MCP23017_INT_ERR 255 //!< Interrupt error
 

--- a/Adafruit_MCP23017.h
+++ b/Adafruit_MCP23017.h
@@ -65,29 +65,29 @@ private:
 #define MCP23017_ADDRESS 0x20 //!< MCP23017 Address
 
 // registers
-#define MCP23017_IODIRA 0x00 //!< I/O direction register A
-#define MCP23017_IPOLA 0x02 //!< Input polarity port register A
+#define MCP23017_IODIRA 0x00   //!< I/O direction register A
+#define MCP23017_IPOLA 0x02    //!< Input polarity port register A
 #define MCP23017_GPINTENA 0x04 //!< Interrupt-on-change pins A
-#define MCP23017_DEFVALA 0x06 //!< Default value register A
-#define MCP23017_INTCONA 0x08 //!< Interrupt-on-change control register A
-#define MCP23017_IOCONA 0x0A //!< I/O expander configuration register A
-#define MCP23017_GPPUA 0x0C //!< GPIO pull-up resistor register A
-#define MCP23017_INTFA 0x0E //!< Interrupt flag register A
-#define MCP23017_INTCAPA 0x10 //!< Interrupt captured value for port register A
-#define MCP23017_GPIOA 0x12 //!< General purpose I/O port register A
-#define MCP23017_OLATA 0x14 //!< Output latch register 0 A
+#define MCP23017_DEFVALA 0x06  //!< Default value register A
+#define MCP23017_INTCONA 0x08  //!< Interrupt-on-change control register A
+#define MCP23017_IOCONA 0x0A   //!< I/O expander configuration register A
+#define MCP23017_GPPUA 0x0C    //!< GPIO pull-up resistor register A
+#define MCP23017_INTFA 0x0E    //!< Interrupt flag register A
+#define MCP23017_INTCAPA 0x10  //!< Interrupt captured value for port register A
+#define MCP23017_GPIOA 0x12    //!< General purpose I/O port register A
+#define MCP23017_OLATA 0x14    //!< Output latch register 0 A
 
-#define MCP23017_IODIRB 0x01 //!< I/O direction register B
-#define MCP23017_IPOLB 0x03 //!< Input polarity port register B
+#define MCP23017_IODIRB 0x01   //!< I/O direction register B
+#define MCP23017_IPOLB 0x03    //!< Input polarity port register B
 #define MCP23017_GPINTENB 0x05 //!< Interrupt-on-change pins B
-#define MCP23017_DEFVALB 0x07 //!< Default value register B
-#define MCP23017_INTCONB 0x09 //!< Interrupt-on-change control register B
-#define MCP23017_IOCONB 0x0B //!< I/O expander configuration register B
-#define MCP23017_GPPUB 0x0D //!< GPIO pull-up resistor register B
-#define MCP23017_INTFB 0x0F //!< Interrupt flag register B
-#define MCP23017_INTCAPB 0x11 //!< Interrupt captured value for port register B
-#define MCP23017_GPIOB 0x13 //!< General purpose I/O port register B
-#define MCP23017_OLATB 0x15 //!< Output latch register 0 B
+#define MCP23017_DEFVALB 0x07  //!< Default value register B
+#define MCP23017_INTCONB 0x09  //!< Interrupt-on-change control register B
+#define MCP23017_IOCONB 0x0B   //!< I/O expander configuration register B
+#define MCP23017_GPPUB 0x0D    //!< GPIO pull-up resistor register B
+#define MCP23017_INTFB 0x0F    //!< Interrupt flag register B
+#define MCP23017_INTCAPB 0x11  //!< Interrupt captured value for port register B
+#define MCP23017_GPIOB 0x13    //!< General purpose I/O port register B
+#define MCP23017_OLATB 0x15    //!< Output latch register 0 B
 
 #define MCP23017_INT_ERR 255 //!< Interrupt error
 


### PR DESCRIPTION
Added readout of output latches using the OLAT register.

Can be useful to restore output states to your program after a reset of the microcontroller.
This way it's not necessary to reset the outputs to get them in sync with your program.
