### PR TITLE
Used wrong variable name for IOCON

### DIFF
--- a/src/Adafruit_MCP23XXX.cpp
+++ b/src/Adafruit_MCP23XXX.cpp
@@ -151,7 +151,7 @@ void Adafruit_MCP23XXX::writeGPIO(uint8_t value, uint8_t port) {
 void Adafruit_MCP23XXX::setupInterrupts(bool mirroring, bool openDrain,
                                         uint8_t polarity) {
   Adafruit_BusIO_Register IOCON(i2c_dev, spi_dev, MCP23XXX_SPIREG,
-                                  getRegister(MCP23XXX_IOCON));
+                                getRegister(MCP23XXX_IOCON));
   Adafruit_BusIO_RegisterBits mirror_bit(&IOCON, 1, 6);
   Adafruit_BusIO_RegisterBits openDrain_bit(&IOCON, 1, 2);
   Adafruit_BusIO_RegisterBits polarity_bit(&IOCON, 1, 1);

--- a/src/Adafruit_MCP23XXX.cpp
+++ b/src/Adafruit_MCP23XXX.cpp
@@ -150,11 +150,11 @@ void Adafruit_MCP23XXX::writeGPIO(uint8_t value, uint8_t port) {
 /**************************************************************************/
 void Adafruit_MCP23XXX::setupInterrupts(bool mirroring, bool openDrain,
                                         uint8_t polarity) {
-  Adafruit_BusIO_Register GPINTEN(i2c_dev, spi_dev, MCP23XXX_SPIREG,
+  Adafruit_BusIO_Register IOCON(i2c_dev, spi_dev, MCP23XXX_SPIREG,
                                   getRegister(MCP23XXX_IOCON));
-  Adafruit_BusIO_RegisterBits mirror_bit(&GPINTEN, 1, 6);
-  Adafruit_BusIO_RegisterBits openDrain_bit(&GPINTEN, 1, 2);
-  Adafruit_BusIO_RegisterBits polarity_bit(&GPINTEN, 1, 1);
+  Adafruit_BusIO_RegisterBits mirror_bit(&IOCON, 1, 6);
+  Adafruit_BusIO_RegisterBits openDrain_bit(&IOCON, 1, 2);
+  Adafruit_BusIO_RegisterBits polarity_bit(&IOCON, 1, 1);
 
   mirror_bit.write(mirroring ? 1 : 0);
   openDrain_bit.write(openDrain ? 1 : 0);


### PR DESCRIPTION
- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This will help us understand any risks of integrating
  the code.

The variable name used in setupInterrupts() is incorrect. Probably a mistake from copy/paste. There is no impact on the correctness of the code, but it is nice to have the proper variable name.

- **Describe any known limitations with your change.**  For example if the change
  doesn't apply to a supported platform of the library please mention it.

No concerns.

- **Please run any tests or examples that can exercise your modified code.**  We
  strive to not break users of the code and running tests/examples helps with this
  process.

Tested and working.