### PR TITLE
Fix doxygen, split up CI jobs

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -15,6 +15,9 @@ jobs:
       with:
          repository: adafruit/ci-arduino
          path: ci
+    
+    - name: move src contents to root
+      run: mv -v src/* .
 
     - name: pre-install
       run: bash ci/actions_install.sh

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -16,20 +16,46 @@ jobs:
          repository: adafruit/ci-arduino
          path: ci
     
-    - name: move src contents to root
-      run: mv -v src/* .
-
     - name: pre-install
       run: bash ci/actions_install.sh
 
     - name: test platforms
       run: python3 ci/build_platform.py main_platforms
+  clang-format:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2
+      with:
+         repository: adafruit/ci-arduino
+         path: ci
+    
+    - name: pre-install
+      run: bash ci/actions_install.sh
 
     - name: clang
       run: python3 ci/run-clang-format.py -e "ci/*" -e "bin/*" -r . 
+  doxygen:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2
+      with:
+         repository: adafruit/ci-arduino
+         path: ci
+    
+    # The Adafruit doxygen setup is configured to only look for files in the root directory
+    - name: move src contents to root
+      run: mv -v src/* .
 
     - name: doxygen
       env:
         GH_REPO_TOKEN: ${{ secrets.GH_REPO_TOKEN }}
         PRETTYNAME : "Adafruit MCP23017 Library"
       run: bash ci/doxy_gen_and_deploy.sh
+

--- a/src/Adafruit_MCP23X08.cpp
+++ b/src/Adafruit_MCP23X08.cpp
@@ -1,23 +1,5 @@
 /*!
  * @file Adafruit_MCP23X08.cpp
- *
- * @mainpage Adafruit MCP23X08/17 Library
- *
- * @section intro_sec Introduction
- *
- * This is a library for the MCP23008/17 I2C and MCP23S08/17 SPI port
- * expanders.
- * Adafruit invests time and resources providing this open source code,
- * please support Adafruit and open-source hardware by purchasing
- * products from Adafruit!
- *
- * @section author Author
- *
- * Written by Carter Nelson for Adafruit Industries.
- *
- * @section license License
- *
- * BSD license, all text above must be included in any redistribution
  */
 
 #include "Adafruit_MCP23X08.h"

--- a/src/Adafruit_MCP23X17.cpp
+++ b/src/Adafruit_MCP23X17.cpp
@@ -1,23 +1,5 @@
 /*!
  * @file Adafruit_MCP23X17.cpp
- *
- * @mainpage Adafruit MCP23X08/17 Library
- *
- * @section intro_sec Introduction
- *
- * This is a library for the MCP23008/17 I2C and MCP23S08/17 SPI port
- * expanders.
- * Adafruit invests time and resources providing this open source code,
- * please support Adafruit and open-source hardware by purchasing
- * products from Adafruit!
- *
- * @section author Author
- *
- * Written by Carter Nelson for Adafruit Industries.
- *
- * @section license License
- *
- * BSD license, all text above must be included in any redistribution
  */
 
 #include "Adafruit_MCP23X17.h"

--- a/src/Adafruit_MCP23XXX.cpp
+++ b/src/Adafruit_MCP23XXX.cpp
@@ -144,7 +144,7 @@ void Adafruit_MCP23XXX::writeGPIO(uint8_t value, uint8_t port) {
 /*!
   @brief Configure the interrupt system.
   @param mirroring true to OR both INTA and INTB pins.
-  @param open true for open drain output, false for active drive output.
+  @param openDrain true for open drain output, false for active drive output.
   @param polarity HIGH or LOW
 */
 /**************************************************************************/
@@ -247,6 +247,7 @@ uint8_t Adafruit_MCP23XXX::getLastInterruptPin() {
   @brief helper to get register address
   @param baseAddress base register address
   @param port 0 for A, 1 for B (MCP23X17 only)
+  @returns calculated register address
 */
 /**************************************************************************/
 uint16_t Adafruit_MCP23XXX::getRegister(uint8_t baseAddress, uint8_t port) {


### PR DESCRIPTION
1. Fixed doxygen by adding a step where all src/ files are moved into the root folder. Adafruit's doxygen config is set to only look for code files in the root directory. This is bit of an ugly hack but it's the least invasive one. Alternatively, the src/ files should just be moved into the root like all other adafruit libraries. Alternatively, adafruit's doxygen config should be updated to also look for files in the src/ dir.
2. Updated files so doxygen doesn't complain anymore now that it actually can find the files.
3. Split the github CI jobs up abit, since they can and should be run independently. (Also, the doxygen fix moving the files breaks the examples for some reason so it's good to isolate that fix to just the doxygen job)