### PR TITLE
Revert Library Name

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
-name=Adafruit MCP23X08/17 Arduino Library
-version=2.0.1
+name=Adafruit MCP23017 Arduino Library
+version=2.0.2
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Arduino Library for MCP23XXX I2C and SPI GPIO port expanders


### PR DESCRIPTION
For #69. Library was renamed as part of #64 to reflect updates to include support for both 08 and 17 variants. Unfortunately, that broke things to the library will not show up in Arduino Library Manager any more. This PR reverts the name.