### PR TITLE
HW Address pins support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,8 @@ MCP23S08 uses addr pins by default. For MCP23S17 address recognition must be ena
 There is hardware bug in the MCP23S17 chip, see "MCP23S17 Rev. A Silicon Errata".
 As a result, if using device with A2 = high, and not using addressing, hw address must be set to 0b1XX
 In such case, even if not using addressing, initalize your MCP23S17 chip with 0b1XX address, eg: mcp.begin_SPI(10, &SPI, 0b100);.
+
+# Warning
+
+Some people have reported an undocumented bug that can potentially corrupt the I2C bus.
+It occurs if an MCP230XX input pin state changes during I2C readout. **This should be very rare.** For more information, see this [forum post](https://www.microchip.com/forums/m646539.aspx) and this [knowledge base article](https://microchipsupport.force.com/s/article/On-MCP23008-MCP23017-SDA-line-change-when-GPIO7-input-change>).

--- a/README.md
+++ b/README.md
@@ -34,3 +34,17 @@ MCP23x08 Pin # | MCP23x17 Pin # | Pin Name | Pin ID
 -- |  6 | GPB5 | 13
 -- |  7 | GPB6 | 14
 -- |  8 | GPB7 | 15
+
+# Use of HW address pins for SPI device
+
+Library supports MCP23Sxx HW pin addressing (A2, A1, A0 for S17 and A1, A0 for S08)
+To use it provide HW address to begin_SPI(CS, SPI, HW_ADDR) function, and as a result each SPI message will contain correct chip address.
+
+Example:
+mcp.begin_SPI(10, &SPI, 0b101);
+
+MCP23S08 uses addr pins by default. For MCP23S17 address recognition must be enabled by enableAddrPins() function. **NOTE** Calling enableAddrPins() will enable IOCON.HAEN bit for all active (CS low) devices on SPI bus.
+**NOTE**
+There is hardware bug in the MCP23S17 chip, see "MCP23S17 Rev. A Silicon Errata".
+As a result, if using device with A2 = high, and not using addressing, hw address must be set to 0b1XX
+In such case, even if not using addressing, initalize your MCP23S17 chip with 0b1XX address, eg: mcp.begin_SPI(10, &SPI, 0b100);.

--- a/src/Adafruit_MCP23X17.cpp
+++ b/src/Adafruit_MCP23X17.cpp
@@ -66,3 +66,35 @@ void Adafruit_MCP23X17::writeGPIOAB(uint16_t value) {
                                getRegister(MCP23XXX_GPIO, 0), 2);
   GPIO.write(value, 2);
 }
+
+/**************************************************************************/
+/*!
+  @brief Enable usage of HW address pins (A0, A1, A2) on MCP23S17
+
+  Send this message as first message after chip init, as it will
+  set bits in IOCON register to default (except HAEN)
+  By default pins are not used and disabled (see README for details)
+  This message is sent to all devices on bus (no hw_addr is added to msg
+  as it's not enabled yet)
+  Due to HW bug in the chip message must be sent twice (to addr 0b000 and
+  0b1xx)
+*/
+/**************************************************************************/
+void Adafruit_MCP23X17::enableAddrPins() {
+  if (!spi_dev) // I2C dev always use addr, only makes sense for SPI dev
+    return;
+
+  Adafruit_BusIO_Register GPIOAddr(i2c_dev, spi_dev, MCP23XXX_SPIREG,
+                                   getRegister(MCP23XXX_IOCON, 0), 2);
+
+  // Send message to address 0b000 regardless of chip addr,
+  // Because addressing is not yet enabled
+  uint8_t tmp = this->hw_addr;
+  this->hw_addr = 0; // Temporary set hw addr to 0
+  Adafruit_BusIO_Register GPIONoAddr(i2c_dev, spi_dev, MCP23XXX_SPIREG,
+                                     getRegister(MCP23XXX_IOCON, 0), 2);
+  this->hw_addr = tmp;
+
+  GPIONoAddr.write((1 << 3), 1); // Bit3: HAEN, devices with A2 = 0
+  GPIOAddr.write((1 << 3), 1);   // Devices with A2 = 1 (if any)
+}

--- a/src/Adafruit_MCP23X17.h
+++ b/src/Adafruit_MCP23X17.h
@@ -22,6 +22,7 @@ public:
   void writeGPIOB(uint8_t value);
   uint16_t readGPIOAB();
   void writeGPIOAB(uint16_t value);
+  void enableAddrPins();
 };
 
 #endif

--- a/src/Adafruit_MCP23XXX.cpp
+++ b/src/Adafruit_MCP23XXX.cpp
@@ -40,10 +40,13 @@ bool Adafruit_MCP23XXX::begin_I2C(uint8_t i2c_addr, TwoWire *wire) {
   @brief Initialize MCP using hardware SPI.
   @param cs_pin Pin to use for SPI chip select
   @param theSPI Pointer to SPI instance
+  @param _hw_addr Hardware address (pins A2, A1, A0)
   @return true if initialization successful, otherwise false.
 */
 /**************************************************************************/
-bool Adafruit_MCP23XXX::begin_SPI(uint8_t cs_pin, SPIClass *theSPI) {
+bool Adafruit_MCP23XXX::begin_SPI(uint8_t cs_pin, SPIClass *theSPI,
+                                  uint8_t _hw_addr) {
+  this->hw_addr = _hw_addr;
   spi_dev = new Adafruit_SPIDevice(cs_pin, 1000000, SPI_BITORDER_MSBFIRST,
                                    SPI_MODE0, theSPI);
   return spi_dev->begin();
@@ -56,18 +59,22 @@ bool Adafruit_MCP23XXX::begin_SPI(uint8_t cs_pin, SPIClass *theSPI) {
   @param sck_pin Pin to use for SPI clock
   @param miso_pin Pin to use for SPI MISO
   @param mosi_pin Pin to use for SPI MOSI
+  @param _hw_addr Hardware address (pins A2, A1, A0)
   @return true if initialization successful, otherwise false.
 */
 /**************************************************************************/
 bool Adafruit_MCP23XXX::begin_SPI(int8_t cs_pin, int8_t sck_pin,
-                                  int8_t miso_pin, int8_t mosi_pin) {
+                                  int8_t miso_pin, int8_t mosi_pin,
+                                  uint8_t _hw_addr) {
+  this->hw_addr = _hw_addr;
   spi_dev = new Adafruit_SPIDevice(cs_pin, sck_pin, miso_pin, mosi_pin);
   return spi_dev->begin();
 }
 
 /**************************************************************************/
 /*!
-  @brief Configures the specified pin to behave either as an input or an output.
+  @brief Configures the specified pin to behave either as an input or an
+  output.
   @param pin the Arduino pin number to set the mode of
   @param mode INPUT, OUTPUT, or INPUT_PULLUP
 */
@@ -262,5 +269,5 @@ uint16_t Adafruit_MCP23XXX::getRegister(uint8_t baseAddress, uint8_t port) {
       reg++;
   }
   // for SPI, add opcode as high byte
-  return (spi_dev) ? (0x4000 | reg) : reg;
+  return (spi_dev) ? (0x4000 | (hw_addr << 9) | reg) : reg;
 }

--- a/src/Adafruit_MCP23XXX.h
+++ b/src/Adafruit_MCP23XXX.h
@@ -39,9 +39,10 @@ class Adafruit_MCP23XXX {
 public:
   // init
   bool begin_I2C(uint8_t i2c_addr = MCP23XXX_ADDR, TwoWire *wire = &Wire);
-  bool begin_SPI(uint8_t cs_pin, SPIClass *theSPI = &SPI);
+  bool begin_SPI(uint8_t cs_pin, SPIClass *theSPI = &SPI,
+                 uint8_t _hw_addr = 0x00);
   bool begin_SPI(int8_t cs_pin, int8_t sck_pin, int8_t miso_pin,
-                 int8_t mosi_pin);
+                 int8_t mosi_pin, uint8_t _hw_addr = 0x00);
 
   // main Arduino API methods
   void pinMode(uint8_t pin, uint8_t mode);
@@ -62,6 +63,7 @@ protected:
   Adafruit_I2CDevice *i2c_dev = NULL; ///< Pointer to I2C bus interface
   Adafruit_SPIDevice *spi_dev = NULL; ///< Pointer to SPI bus interface
   uint8_t pinCount;                   ///< Total number of GPIO pins
+  uint8_t hw_addr;                    ///< HW address matching A2/A1/A0 pins
   uint16_t getRegister(uint8_t baseAddress, uint8_t port = 0);
 
 private:


### PR DESCRIPTION
Hi,

I needed support for HW addressing for MCP23S17 (SPI) chip so I implemented it.
Change is not breaking API, default argument was added to begin_spi method, so old code using this library will work.

User may pass 3rg argument to begin_spi method to use HW addressing:
mcpchip.begin_SPI(MCP_DOOR_CS, &SPI, 0b100); 
If no argument is provided address 0 is used (as up to now).

To enable HW addressing on MCP23S17 chip, bit in config register must be set, and this can be done by invoking method enableAddrPins();

One note: There is HW bug in the MCP23S17 chip related to HW addressing that is described in "errata note". My commit also takes it into account. As a result, enableAddrPins() must write bit twice (to devices with addr 0b0xx and 0b1xx separately).

I checked it on MCP23S17 chip with different HW addresses (0b000, 0b0xx, 0b1xx).
It should work for MCP23S08 also, however I didn't have chip to test it.