### PR TITLE
Added 'value' field to the getLastInterruptPin function

### DIFF
--- a/src/Adafruit_MCP23XXX.cpp
+++ b/src/Adafruit_MCP23XXX.cpp
@@ -239,7 +239,7 @@ uint8_t Adafruit_MCP23XXX::getLastInterruptPin(uint8_t *value = NULL) {
         i2c_dev, spi_dev, MCP23XXX_SPIREG,
         getRegister(MCP23XXX_INTCAP, MCP_PORT(intpin)));
     INTCAP.read(value);
-    if(value) { *value=(*value>>intpin)&0x1; }
+    if(value) { *value=(*value>>(intpin%8))&0x1; }
   }
 
   return intpin;

--- a/src/Adafruit_MCP23XXX.cpp
+++ b/src/Adafruit_MCP23XXX.cpp
@@ -202,9 +202,10 @@ void Adafruit_MCP23XXX::disableInterruptPin(uint8_t pin) {
 /*!
   @brief Gets the last interrupt pin.
   @returns Pin that caused last interrupt.
+  @param value will be updated with the value that caused the interrupt
 */
 /**************************************************************************/
-uint8_t Adafruit_MCP23XXX::getLastInterruptPin() {
+uint8_t Adafruit_MCP23XXX::getLastInterruptPin(uint8_t *value = NULL) {
   uint8_t intpin = 255;
   uint8_t intf;
 
@@ -237,7 +238,8 @@ uint8_t Adafruit_MCP23XXX::getLastInterruptPin() {
     Adafruit_BusIO_Register INTCAP(
         i2c_dev, spi_dev, MCP23XXX_SPIREG,
         getRegister(MCP23XXX_INTCAP, MCP_PORT(intpin)));
-    INTCAP.read();
+    INTCAP.read(value);
+    if(value) { *value=(*value>>intpin)&0x1; }
   }
 
   return intpin;

--- a/src/Adafruit_MCP23XXX.h
+++ b/src/Adafruit_MCP23XXX.h
@@ -56,7 +56,7 @@ public:
   void setupInterrupts(bool mirroring, bool openDrain, uint8_t polarity);
   void setupInterruptPin(uint8_t pin, uint8_t mode = CHANGE);
   void disableInterruptPin(uint8_t pin);
-  uint8_t getLastInterruptPin();
+  uint8_t getLastInterruptPin(uint8_t *value = NULL);
 
 protected:
   Adafruit_I2CDevice *i2c_dev = NULL; ///< Pointer to I2C bus interface


### PR DESCRIPTION
In the getLastInterruptPin function, the INTCAP value is read to clear the interrupt, but without an argument, so the actual value of INTCAP is lost. As this contains the value that caused the interrupt, it is worth keeping - the current value of the pin may have changed since, so a digitalRead isn't ideal - especially if the MCP23008 stores the value that caused the interrupt in the first place.

Patch to add a pointer to an optional 'value' argument that will return the INTCAP value. As it's an optional argument, it doesn't change existing calls to the function that didn't care about the INTCAP value and didn't supply somewhere to store it.
