### PR TITLE
Add enableAddrPins() for MCP23X08

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,24 +16,24 @@ To install, use the Arduino IDE Library Manager.
 
 When using single pin operations such as _pinMode(pinId, dir)_ or _digitalRead(pinId)_  or _digitalWrite(pinId, val)_ then the pins are addressed using the ID's below. For example, for set the mode of _GPB0_ then use _pinMode(8, ...)_. **NOTE** The MCP23008 and MCP23S08 only have _GPAx_ pins.
 
-MCP23x08 Pin # | MCP23x17 Pin # | Pin Name | Pin ID
-:-------------:|:--------------:|:--------:|:-------:
-10 | 21 | GPA0 | 0
-11 | 22 | GPA1 | 1
-12 | 23 | GPA2 | 2
-13 | 24 | GPA3 | 3
-14 | 25 | GPA4 | 4
-15 | 26 | GPA5 | 5
-16 | 27 | GPA6 | 6
-17 | 28 | GPA7 | 7
--- |  1 | GPB0 |  8
--- |  2 | GPB1 |  9
--- |  3 | GPB2 | 10
--- |  4 | GPB3 | 11
--- |  5 | GPB4 | 12
--- |  6 | GPB5 | 13
--- |  7 | GPB6 | 14
--- |  8 | GPB7 | 15
+| MCP23x08 Pin # | MCP23x17 Pin # | Pin Name | Pin ID |
+| :------------: | :------------: | :------: | :----: |
+|       10       |       21       |   GPA0   |   0    |
+|       11       |       22       |   GPA1   |   1    |
+|       12       |       23       |   GPA2   |   2    |
+|       13       |       24       |   GPA3   |   3    |
+|       14       |       25       |   GPA4   |   4    |
+|       15       |       26       |   GPA5   |   5    |
+|       16       |       27       |   GPA6   |   6    |
+|       17       |       28       |   GPA7   |   7    |
+|       --       |       1        |   GPB0   |   8    |
+|       --       |       2        |   GPB1   |   9    |
+|       --       |       3        |   GPB2   |   10   |
+|       --       |       4        |   GPB3   |   11   |
+|       --       |       5        |   GPB4   |   12   |
+|       --       |       6        |   GPB5   |   13   |
+|       --       |       7        |   GPB6   |   14   |
+|       --       |       8        |   GPB7   |   15   |
 
 # Use of HW address pins for SPI device
 
@@ -43,7 +43,7 @@ To use it provide HW address to begin_SPI(CS, SPI, HW_ADDR) function, and as a r
 Example:
 mcp.begin_SPI(10, &SPI, 0b101);
 
-MCP23S08 uses addr pins by default. For MCP23S17 address recognition must be enabled by enableAddrPins() function. **NOTE** Calling enableAddrPins() will enable IOCON.HAEN bit for all active (CS low) devices on SPI bus.
+HW Address recognition must be enabled by enableAddrPins() function. **NOTE** Calling enableAddrPins() will enable IOCON.HAEN bit for all active (CS low) devices on SPI bus.
 **NOTE**
 There is hardware bug in the MCP23S17 chip, see "MCP23S17 Rev. A Silicon Errata".
 As a result, if using device with A2 = high, and not using addressing, hw address must be set to 0b1XX

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit MCP23017 Arduino Library
-version=2.1.1
+version=2.2.0
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Arduino Library for MCP23XXX I2C and SPI GPIO port expanders

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit MCP23017 Arduino Library
-version=2.1.0
+version=2.1.1
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Arduino Library for MCP23XXX I2C and SPI GPIO port expanders

--- a/src/Adafruit_MCP23X08.cpp
+++ b/src/Adafruit_MCP23X08.cpp
@@ -22,7 +22,7 @@ Adafruit_MCP23X08::Adafruit_MCP23X08() { pinCount = 8; }
 */
 /**************************************************************************/
 void Adafruit_MCP23X08::enableAddrPins() {
-  if (!spi_dev)  // I2C dev always use addr, only makes sense for SPI dev
+  if (!spi_dev) // I2C dev always use addr, only makes sense for SPI dev
     return;
 
   Adafruit_BusIO_Register GPIOAddr(i2c_dev, spi_dev, MCP23XXX_SPIREG,

--- a/src/Adafruit_MCP23X08.cpp
+++ b/src/Adafruit_MCP23X08.cpp
@@ -10,3 +10,23 @@
 */
 /**************************************************************************/
 Adafruit_MCP23X08::Adafruit_MCP23X08() { pinCount = 8; }
+
+/**************************************************************************/
+/*!
+  @brief Enable usage of HW address pins (A0, A1) on MCP23S08
+
+  Send this message as first message after chip init.
+
+  By default HW address pins are disabled.
+  (Register IOCON, bit HAEN = 0 on chip reset)
+*/
+/**************************************************************************/
+void Adafruit_MCP23X08::enableAddrPins() {
+  if (!spi_dev)  // I2C dev always use addr, only makes sense for SPI dev
+    return;
+
+  Adafruit_BusIO_Register GPIOAddr(i2c_dev, spi_dev, MCP23XXX_SPIREG,
+                                   getRegister(MCP23XXX_IOCON, 0), 2);
+
+  GPIOAddr.write((1 << 3), 1);
+}

--- a/src/Adafruit_MCP23X08.h
+++ b/src/Adafruit_MCP23X08.h
@@ -13,7 +13,7 @@
 */
 /**************************************************************************/
 class Adafruit_MCP23X08 : public Adafruit_MCP23XXX {
- public:
+public:
   Adafruit_MCP23X08();
 
   void enableAddrPins();

--- a/src/Adafruit_MCP23X08.h
+++ b/src/Adafruit_MCP23X08.h
@@ -13,8 +13,10 @@
 */
 /**************************************************************************/
 class Adafruit_MCP23X08 : public Adafruit_MCP23XXX {
-public:
+ public:
   Adafruit_MCP23X08();
+
+  void enableAddrPins();
 };
 
 #endif


### PR DESCRIPTION
MCP23S08 hardware address pins A1 and A0 are not enabled by default on chip reset.
[(See Microchip datasheet page 14)](https://ww1.microchip.com/downloads/en/DeviceDoc/21919e.pdf)

This pull request add the following function to the class **Adafruit_MCP23X08**
```void enableAddrPins();```

Otherwise the library does not work with HW address pins on MCP23S08.

README.md is modified accordingly.
