### PR TITLE
Add INTCAP support

### DIFF
--- a/examples/mcp23xxx_interrupt/mcp23xxx_interrupt.ino
+++ b/examples/mcp23xxx_interrupt/mcp23xxx_interrupt.ino
@@ -55,6 +55,12 @@ void loop() {
   if (!digitalRead(INT_PIN)) {
     Serial.print("Interrupt detected on pin: ");
     Serial.println(mcp.getLastInterruptPin());
-    delay(250); // debounce
+    Serial.print("Pin states at time of interrupt: 0b");
+    Serial.println(mcp.getCapturedInterrupt(), 2);
+    delay(250);  // debounce
+    // NOTE: If using DEFVAL, INT clears only if interrupt
+    // condition does not exist.
+    // See Fig 1-7 in datasheet.
+    mcp.clearInterrupts();  // clear
   }
 }

--- a/src/Adafruit_MCP23XXX.h
+++ b/src/Adafruit_MCP23XXX.h
@@ -30,6 +30,8 @@
 
 #define MCP_PORT(pin) ((pin < 8) ? 0 : 1) //!< Determine port from pin number
 
+#define MCP23XXX_INT_ERR 255 //!< Interrupt error
+
 /**************************************************************************/
 /*!
     @brief  Base class for all MCP23XXX variants.
@@ -57,7 +59,9 @@ public:
   void setupInterrupts(bool mirroring, bool openDrain, uint8_t polarity);
   void setupInterruptPin(uint8_t pin, uint8_t mode = CHANGE);
   void disableInterruptPin(uint8_t pin);
+  void clearInterrupts();
   uint8_t getLastInterruptPin();
+  uint16_t getCapturedInterrupt();
 
 protected:
   Adafruit_I2CDevice *i2c_dev = NULL; ///< Pointer to I2C bus interface


### PR DESCRIPTION
For #86.

Tested using updated `mcp23xxx_interrupt.ino` example with an MCP23008. Slightly modified with button on pin 0. Other pins connected to 3V or GND in no specific order to generate INTCAP result.

```
13:28:16.953 -> MCP23xxx Interrupt Test!
13:28:17.041 -> Looping...
13:28:17.946 -> Interrupt detected on pin: 0
13:28:17.946 -> Pin states at time of interrupt: 0b10100010
13:28:20.827 -> Interrupt detected on pin: 0
13:28:20.827 -> Pin states at time of interrupt: 0b10100010
13:28:22.979 -> Interrupt detected on pin: 0
13:28:22.979 -> Pin states at time of interrupt: 0b10100010
```