### PR TITLE
Add parameter for SPI clock frequency to begin_SPI() functions

### DIFF
--- a/src/Adafruit_MCP23XXX.cpp
+++ b/src/Adafruit_MCP23XXX.cpp
@@ -41,13 +41,14 @@ bool Adafruit_MCP23XXX::begin_I2C(uint8_t i2c_addr, TwoWire *wire) {
   @param cs_pin Pin to use for SPI chip select
   @param theSPI Pointer to SPI instance
   @param _hw_addr Hardware address (pins A2, A1, A0)
+  @param freq SPI clock frequency to use in Hz. Defaults to 1MHz
   @return true if initialization successful, otherwise false.
 */
 /**************************************************************************/
 bool Adafruit_MCP23XXX::begin_SPI(uint8_t cs_pin, SPIClass *theSPI,
-                                  uint8_t _hw_addr) {
+                                  uint8_t _hw_addr, uint32_t freq) {
   this->hw_addr = _hw_addr;
-  spi_dev = new Adafruit_SPIDevice(cs_pin, 1000000, SPI_BITORDER_MSBFIRST,
+  spi_dev = new Adafruit_SPIDevice(cs_pin, freq, SPI_BITORDER_MSBFIRST,
                                    SPI_MODE0, theSPI);
   return spi_dev->begin();
 }
@@ -60,14 +61,15 @@ bool Adafruit_MCP23XXX::begin_SPI(uint8_t cs_pin, SPIClass *theSPI,
   @param miso_pin Pin to use for SPI MISO
   @param mosi_pin Pin to use for SPI MOSI
   @param _hw_addr Hardware address (pins A2, A1, A0)
+  @param freq SPI clock frequency to use in Hz. Defaults to 1MHz
   @return true if initialization successful, otherwise false.
 */
 /**************************************************************************/
 bool Adafruit_MCP23XXX::begin_SPI(int8_t cs_pin, int8_t sck_pin,
                                   int8_t miso_pin, int8_t mosi_pin,
-                                  uint8_t _hw_addr) {
+                                  uint8_t _hw_addr, uint32_t freq) {
   this->hw_addr = _hw_addr;
-  spi_dev = new Adafruit_SPIDevice(cs_pin, sck_pin, miso_pin, mosi_pin);
+  spi_dev = new Adafruit_SPIDevice(cs_pin, sck_pin, miso_pin, mosi_pin, freq);
   return spi_dev->begin();
 }
 

--- a/src/Adafruit_MCP23XXX.h
+++ b/src/Adafruit_MCP23XXX.h
@@ -42,9 +42,10 @@ public:
   // init
   bool begin_I2C(uint8_t i2c_addr = MCP23XXX_ADDR, TwoWire *wire = &Wire);
   bool begin_SPI(uint8_t cs_pin, SPIClass *theSPI = &SPI,
-                 uint8_t _hw_addr = 0x00);
+                 uint8_t _hw_addr = 0x00, uint32_t freq = 1000000);
   bool begin_SPI(int8_t cs_pin, int8_t sck_pin, int8_t miso_pin,
-                 int8_t mosi_pin, uint8_t _hw_addr = 0x00);
+                 int8_t mosi_pin, uint8_t _hw_addr = 0x00,
+                 uint32_t freq = 1000000);
 
   // main Arduino API methods
   void pinMode(uint8_t pin, uint8_t mode);


### PR DESCRIPTION
This allows to configure the used SPI clock frequency for the SPI variants, instead of using the hard coded 1 Mhz.

It should not break anything or change the behavior of existing code.

Let me know if you need anything else :)
