### PR TITLE
Added MCP23018 class with support for Pullup on Output

### DIFF
--- a/src/Adafruit_MCP23X17.cpp
+++ b/src/Adafruit_MCP23X17.cpp
@@ -98,3 +98,32 @@ void Adafruit_MCP23X17::enableAddrPins() {
   GPIONoAddr.write((1 << 3), 1); // Bit3: HAEN, devices with A2 = 0
   GPIOAddr.write((1 << 3), 1);   // Devices with A2 = 1 (if any)
 }
+
+/**************************************************************************/
+/*!
+  @brief Get pin states captured at time of interrupt on Port A.
+  @returns Mutli-bit value representing pin states.
+*/
+/**************************************************************************/
+uint8_t Adafruit_MCP23X17::getCapturedInterruptA() {
+  uint8_t intcap;
+
+  Adafruit_BusIO_Register INTCAPA(i2c_dev, spi_dev, MCP23XXX_SPIREG,
+                                  getRegister(MCP23XXX_INTCAP, 0));
+  INTCAPA.read(&intcap);
+  return intcap;
+}
+
+/**************************************************************************/
+/*!
+  @brief Get pin states captured at time of interrupt on Port B.
+  @returns Mutli-bit value representing pin states.
+*/
+/**************************************************************************/
+uint8_t Adafruit_MCP23X17::getCapturedInterruptB() {
+  uint8_t intcap;
+    Adafruit_BusIO_Register INTCAPB(i2c_dev, spi_dev, MCP23XXX_SPIREG,
+                                    getRegister(MCP23XXX_INTCAP, 1));
+    INTCAPB.read(&intcap);
+    return intcap;
+}

--- a/src/Adafruit_MCP23X17.h
+++ b/src/Adafruit_MCP23X17.h
@@ -23,6 +23,8 @@ public:
   uint16_t readGPIOAB();
   void writeGPIOAB(uint16_t value);
   void enableAddrPins();
+  uint8_t getCapturedInterruptA();
+  uint8_t getCapturedInterruptB();
 };
 
 #endif

--- a/src/Adafruit_MCP23X18.cpp
+++ b/src/Adafruit_MCP23X18.cpp
@@ -27,6 +27,6 @@ void Adafruit_MCP23X18::pinMode(uint8_t pin, uint8_t mode) {
   Adafruit_BusIO_RegisterBits dir_bit(&IODIR, 1, pin % 8);
   Adafruit_BusIO_RegisterBits pullup_bit(&GPPU, 1, pin % 8);
 
-  dir_bit.write((mode == OUTPUT) ? 0 : 1); 
+  dir_bit.write((mode == OUTPUT) ? 0 : 1);
   pullup_bit.write((mode == INPUT_PULLUP || mode == OUTPUT_PULLUP) ? 1 : 0);
 }

--- a/src/Adafruit_MCP23X18.cpp
+++ b/src/Adafruit_MCP23X18.cpp
@@ -1,0 +1,32 @@
+/*!
+ * @file Adafruit_MCP23X18.cpp
+ */
+
+#include "Adafruit_MCP23X18.h"
+
+/**************************************************************************/
+/*!
+  @brief default ctor.
+*/
+/**************************************************************************/
+Adafruit_MCP23X18::Adafruit_MCP23X18() { pinCount = 16; }
+
+/**************************************************************************/
+/*!
+  @brief Configures the specified pin to behave either as an input or an
+  output.
+  @param pin the Arduino pin number to set the mode of
+  @param mode INPUT, OUTPUT, or INPUT_PULLUP
+*/
+/**************************************************************************/
+void Adafruit_MCP23X18::pinMode(uint8_t pin, uint8_t mode) {
+  Adafruit_BusIO_Register IODIR(i2c_dev, spi_dev, MCP23XXX_SPIREG,
+                                getRegister(MCP23XXX_IODIR, MCP_PORT(pin)));
+  Adafruit_BusIO_Register GPPU(i2c_dev, spi_dev, MCP23XXX_SPIREG,
+                               getRegister(MCP23XXX_GPPU, MCP_PORT(pin)));
+  Adafruit_BusIO_RegisterBits dir_bit(&IODIR, 1, pin % 8);
+  Adafruit_BusIO_RegisterBits pullup_bit(&GPPU, 1, pin % 8);
+
+  dir_bit.write((mode == OUTPUT) ? 0 : 1); 
+  pullup_bit.write((mode == INPUT_PULLUP || mode == OUTPUT_PULLUP) ? 1 : 0);
+}

--- a/src/Adafruit_MCP23X18.h
+++ b/src/Adafruit_MCP23X18.h
@@ -17,7 +17,7 @@
 class Adafruit_MCP23X18 : public Adafruit_MCP23X17 {
 public:
   Adafruit_MCP23X18();
-  
+
   void pinMode(uint8_t pin, uint8_t mode);
 };
 

--- a/src/Adafruit_MCP23X18.h
+++ b/src/Adafruit_MCP23X18.h
@@ -19,7 +19,6 @@ public:
   Adafruit_MCP23X18();
   
   void pinMode(uint8_t pin, uint8_t mode);
-
 };
 
 #endif

--- a/src/Adafruit_MCP23X18.h
+++ b/src/Adafruit_MCP23X18.h
@@ -7,7 +7,7 @@
 
 #include "Adafruit_MCP23X17.h"
 
-#define OUTPUT_PULLUP 4
+#define OUTPUT_PULLUP 4 //!< Additional define for Output with Pullup
 
 /**************************************************************************/
 /*!

--- a/src/Adafruit_MCP23X18.h
+++ b/src/Adafruit_MCP23X18.h
@@ -1,0 +1,25 @@
+/*!
+ * @file Adafruit_MCP23X18.h
+ */
+
+#ifndef __ADAFRUIT_MCP23X18_H__
+#define __ADAFRUIT_MCP23X18_H__
+
+#include "Adafruit_MCP23X17.h"
+
+#define OUTPUT_PULLUP 4
+
+/**************************************************************************/
+/*!
+    @brief  Class for MCP23018 I2C and MCP23S18 SPI variants.
+*/
+/**************************************************************************/
+class Adafruit_MCP23X18 : public Adafruit_MCP23X17 {
+public:
+  Adafruit_MCP23X18();
+  
+  void pinMode(uint8_t pin, uint8_t mode);
+
+};
+
+#endif


### PR DESCRIPTION
This is a simple change adding a MCP23X18 class so that I can add support for pullup on a output pin.

Im not sure if there's any other major differences to the MCP23X17 that could also be added.

Thanks